### PR TITLE
feat(nav): implement bottom navigation bar with Alerts and Emergency screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -61,7 +61,7 @@ dependencies {
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.foundation)
-
+    implementation(libs.androidx.material.icons.extended)
     // Navigation Compose
     implementation(libs.androidx.navigation.compose)
 

--- a/app/src/main/java/com/felipe/santos/safemap/MainActivity.kt
+++ b/app/src/main/java/com/felipe/santos/safemap/MainActivity.kt
@@ -4,12 +4,17 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.rememberNavController
 import com.felipe.santos.safemap.presentation.navigation.AppNavHost
+import com.felipe.santos.safemap.presentation.navigation.bottom.BottomNavBar
 import com.felipe.santos.safemap.presentation.ui.theme.SafeMapTheme
 import com.google.firebase.FirebaseApp
 import dagger.hilt.android.AndroidEntryPoint
@@ -27,12 +32,17 @@ class MainActivity : ComponentActivity() {
                 val navController = rememberNavController()
 
                 Scaffold(
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize(),
+                    bottomBar = {  BottomNavBar(navController = navController)}
                 ) { paddingValues ->
+
                     AppNavHost(
                         modifier = Modifier.padding(paddingValues),
                         navController = navController
                     )
+
+
+
                 }
             }
         }

--- a/app/src/main/java/com/felipe/santos/safemap/presentation/alerts/AlertsScreen.kt
+++ b/app/src/main/java/com/felipe/santos/safemap/presentation/alerts/AlertsScreen.kt
@@ -1,0 +1,10 @@
+package com.felipe.santos.safemap.presentation.alerts
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun AlertsScreen(modifier: Modifier = Modifier) {
+    Text("Hello from Alert")
+}

--- a/app/src/main/java/com/felipe/santos/safemap/presentation/emergency/EmergencyScreen.kt
+++ b/app/src/main/java/com/felipe/santos/safemap/presentation/emergency/EmergencyScreen.kt
@@ -1,0 +1,10 @@
+package com.felipe.santos.safemap.presentation.emergency
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun EmergencyScreen(modifier: Modifier = Modifier) {
+    Text("Hello from emergency")
+}

--- a/app/src/main/java/com/felipe/santos/safemap/presentation/navigation/NavDestination.kt
+++ b/app/src/main/java/com/felipe/santos/safemap/presentation/navigation/NavDestination.kt
@@ -5,8 +5,10 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.felipe.santos.safemap.presentation.alerts.AlertsScreen
 import com.felipe.santos.safemap.presentation.authentication.accessdenied.AccessDeniedScreen
 import com.felipe.santos.safemap.presentation.authentication.splashscreen.SplashScreen
+import com.felipe.santos.safemap.presentation.emergency.EmergencyScreen
 import com.felipe.santos.safemap.presentation.home.SafeMapScreen
 import kotlinx.serialization.Serializable
 
@@ -18,6 +20,12 @@ object SafeMap
 
 @Serializable
 object AccessDenied
+
+@Serializable
+object Alerts
+
+@Serializable
+object Emergency
 
 @Composable
 fun AppNavHost(
@@ -38,5 +46,14 @@ fun AppNavHost(
         composable <SafeMap>{
             SafeMapScreen()
         }
+
+        composable<Alerts> {
+            AlertsScreen()
+        }
+
+        composable<Emergency> {
+            EmergencyScreen()
+        }
+
     }
 }

--- a/app/src/main/java/com/felipe/santos/safemap/presentation/navigation/bottom/BottomNavBar.kt
+++ b/app/src/main/java/com/felipe/santos/safemap/presentation/navigation/bottom/BottomNavBar.kt
@@ -1,0 +1,114 @@
+package com.felipe.santos.safemap.presentation.navigation.bottom
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.compose.currentBackStackEntryAsState
+import com.felipe.santos.safemap.presentation.navigation.Alerts
+import com.felipe.santos.safemap.presentation.navigation.Emergency
+
+@Composable
+fun BottomNavBar(navController: NavController) {
+    val bottomNavDestinations = remember {
+        listOf(
+            BottomNavItems.Home,
+            BottomNavItems.Favorites,
+        )
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(96.dp),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        NavigationBar(
+            containerColor = MaterialTheme.colorScheme.surface,
+            tonalElevation = 4.dp,
+            modifier = Modifier
+                .fillMaxSize()
+
+        ) {
+            bottomNavDestinations.forEach { destination ->
+                val navBackStackEntry by navController.currentBackStackEntryAsState()
+                val currentDestination = navBackStackEntry?.destination
+                val isSelected = currentDestination?.hierarchy?.any {
+                    it.route == destination.route
+                } == true
+
+                NavigationBarItem(
+                    selected = isSelected,
+                    onClick = {
+                        navController.navigate(destination.route) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState = true
+                        }
+                    },
+                    icon = {
+                        Icon(
+                            imageVector = destination.icon,
+                            contentDescription = destination.label
+                        )
+                    },
+                    label = {
+                        Text(text = destination.label)
+                    },
+                    colors = NavigationBarItemDefaults.colors(
+                        selectedIconColor = MaterialTheme.colorScheme.primary,
+                        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        selectedTextColor = MaterialTheme.colorScheme.primary,
+                        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                        indicatorColor = MaterialTheme.colorScheme.surfaceVariant
+                    )
+                )
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .size(80.dp)
+                .offset(y = (-55).dp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.primary)
+                .clickable {
+                    navController.navigate(Emergency)
+                },
+            contentAlignment = Alignment.Center
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Warning,
+                contentDescription = "Emergency",
+                tint = MaterialTheme.colorScheme.onPrimary,
+                modifier = Modifier.size(28.dp)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/felipe/santos/safemap/presentation/navigation/bottom/BottomNavItems.kt
+++ b/app/src/main/java/com/felipe/santos/safemap/presentation/navigation/bottom/BottomNavItems.kt
@@ -1,0 +1,36 @@
+package com.felipe.santos.safemap.presentation.navigation.bottom
+
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.felipe.santos.safemap.presentation.navigation.Alerts
+import com.felipe.santos.safemap.presentation.navigation.SafeMap
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+
+
+
+@Serializable
+sealed class BottomNavItems<T>(val label: String, val icon: @Contextual ImageVector, val route: T) {
+    @Serializable
+    data object Home : BottomNavItems<SafeMap>(
+        label = HOME_LABEL,
+        icon = Icons.Filled.Home,
+        route = SafeMap
+    )
+
+    @Serializable
+    data object Favorites : BottomNavItems<Alerts>(
+        label = ALERT_LABEL,
+        icon = Icons.Filled.Notifications,
+        route = Alerts
+    )
+
+    companion object {
+        private const val HOME_LABEL = "Home"
+        private const val ALERT_LABEL = "Alerts"
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ playServicesMaps = "19.1.0"
 retrofit = "2.11.0"
 retrofitKotlinSerialization = "1.0.0"
 okhttpLogging = "4.12.0"
+materialIconsExtended = "1.7.8"
+
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -46,6 +48,7 @@ androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-man
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }


### PR DESCRIPTION
## ✅ Pull Request Title

feat(nav): implement bottom navigation bar with Alerts and Emergency screens

---

## 📝 Description

This PR introduces the initial implementation of the **bottom navigation bar** for the Safe Map app.

It includes:
- A new `BottomNavBar` composable with type-safe navigation
- Definition of `BottomNavItems` with icon, label, and route
- Creation of placeholder screens for `Alerts` and `Emergency`
- Integration of the bottom navigation with `MainActivity` and `NavHost`
- Clean separation of navigation logic using `NavDestination.kt`

These changes establish the core structure for app navigation, improving usability and paving the way for future features like user profile, community posts, or map-related tabs.

---

## 📂 Changed Files

- `BottomNavBar.kt`
- `BottomNavItems.kt`
- `NavDestination.kt`
- `MainActivity.kt`
- `AlertsScreen.kt`
- `EmergencyScreen.kt`
- `build.gradle.kts`
- `libs.versions.toml`

---

## 🔍 Test Plan

- [x] Bottom navigation appears with correct icons and labels
- [x] Navigation between Alerts and Emergency works as expected
- [x] Screens recompose properly when switching tabs
- [x] Safe back navigation behavior
- [x] Build runs successfully on emulator and physical device

---

## 📦 Dependencies

- Jetpack Compose Navigation
- Material 3

---

## ⚠️ Notes

- Navigation destinations are strongly typed using a sealed class
- Each screen is organized in its own package for scalability
- More tabs (e.g. Profile, Map) can be easily added by extending `BottomNavItems`

---

## 📸 Screenshots

<!-- (Optional) Add screenshots here if available -->